### PR TITLE
Change service to serivce provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,35 @@ If you want to use a secure token pass it along with the site key as an html att
 Please note that you have to enrypt your token yourself with your private key upfront!
 To learn more about secure tokens and how to generate & encrypt them please refer to the [reCAPTCHA Docs](https://developers.google.com/recaptcha/docs/secure_token).
 
+Service Provider
+----------------
+You can use the vcRecaptchaServiceProvider to configure the recaptcha service once in your application's config function.
+This is a convenient way to set your reCaptcha site key, theme, stoken, size, and type in one place instead of each vc-recaptcha directive element instance.
+The defaults defined in the service provider will be overrode by any values passed to the vc-recaptcha directive element for that instance.
+
+```javascript
+myApp.config(function(vcRecaptchaServiceProvider){
+  vcRecaptchaServiceProvider.setSiteKey('---- YOUR PUBLIC KEY GOES HERE ----')
+  vcRecaptchaServiceProvider.setTheme('---- light or dark ----')
+  vcRecaptchaServiceProvider.setStoken('--- YOUR GENERATED SECURE TOKEN ---')
+  vcRecaptchaServiceProvider.setSize('---- compact or normal ----')
+  vcRecaptchaServiceProvider.setType('---- audio or image ----')
+});
+```
+
+You can also set all of the values at once.
+
+```javascript
+myApp.config(function(vcRecaptchaServiceProvider){
+  vcRecaptchaServiceProvider.setDefaults({
+  key: '---- YOUR PUBLIC KEY GOES HERE ----',
+  theme: '---- light or dark ----',
+  stoken: '--- YOUR GENERATED SECURE TOKEN ---',
+  size: '---- compact or normal ----',
+  type: '---- audio or image ----'
+});
+```
+Note: any value omitted will be undefined, even if previously set.
 
 Differences with the old reCaptcha
 ----------------------------------

--- a/src/directive.js
+++ b/src/directive.js
@@ -2,10 +2,6 @@
 (function (ng) {
     'use strict';
 
-    function throwNoKeyException() {
-        throw new Error('You need to set the "key" attribute to your public reCaptcha key. If you don\'t have a key, please get one from https://www.google.com/recaptcha/admin/create');
-    }
-
     var app = ng.module('vcRecaptcha');
 
     app.directive('vcRecaptcha', ['$document', '$timeout', 'vcRecaptchaService', function ($document, $timeout, vcRecaptcha) {
@@ -15,7 +11,7 @@
             require: "?^^form",
             scope: {
                 response: '=?ngModel',
-                key: '=',
+                key: '=?',
                 stoken: '=?',
                 theme: '=?',
                 size: '=?',
@@ -25,22 +21,10 @@
                 onExpire: '&'
             },
             link: function (scope, elm, attrs, ctrl) {
-                if (!attrs.hasOwnProperty('key')) {
-                    throwNoKeyException();
-                }
-
                 scope.widgetId = null;
 
                 var sessionTimeout;
                 var removeCreationListener = scope.$watch('key', function (key) {
-                    if (!key) {
-                        return;
-                    }
-
-                    if (key.length !== 40) {
-                        throwNoKeyException();
-                    }
-
                     var callback = function (gRecaptchaResponse) {
                         // Safe $apply
                         $timeout(function () {
@@ -63,8 +47,10 @@
                         }, 2 * 60 * 1000);
                     };
 
-                    vcRecaptcha.create(elm[0], key, callback, {
+                    vcRecaptcha.create(elm[0], {
 
+                        callback: callback,
+                        key: key,
                         stoken: scope.stoken || attrs.stoken || null,
                         theme: scope.theme || attrs.theme || null,
                         tabindex: scope.tabindex || attrs.tabindex || null,


### PR DESCRIPTION
Resolves #98 by changing  the service to a service provider which allows the user to set default values for the site key, theme, stoken, size, and type. These
defaults can be overridden by setting the values on individual instances
of the directive.
The key validation has been moved out of the directive and into the
service since now the directive does not require a key (as it can use the
default defined in the provider during the config by the user).